### PR TITLE
Fix/14 Put Claude Md Back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Legacy deployment migration in update command** - `trinity update` now detects pre-2.2.0
+  `trinity/` deployments at project root and automatically migrates them to `.claude/trinity/`
+  (Issue #14)
+  - New `migration.ts` module with `detectLegacyDeployment()`, `migrateLegacyDeployment()`,
+    and `updateGitignoreForMigration()`
+  - Pre-flight checks updated to recognize legacy layouts instead of failing
+  - Version detection falls back to `trinity/VERSION` for legacy deployments
+  - User knowledge base files preserved during migration
+- **Gitignore migration in update command** - `trinity update` now updates `.gitignore`
+  patterns on every run, replacing old `trinity/` entries with current `.claude/trinity/`
+  patterns (Issue #14)
+
+### Fixed
+
+- **Restored `*CLAUDE.md` to deploy gitignore patterns** - `trinity deploy` now adds
+  `*CLAUDE.md` back to `.gitignore`, preventing project-specific CLAUDE.md files from being
+  committed to version control (Issue #14)
+- **depcheck false positive for `markdownlint-cli`** - Added `markdownlint-cli` to depcheck
+  ignores in CI workflow since it is used by npm scripts, not imported in code
+- **Integration test timeout on Windows CI** - Bumped integration test timeout from 60s to
+  120s in `jest.config.js` for slow Windows runners
+
 ## [2.2.0] - 2026-02-24
 
 ### Added

--- a/src/cli/commands/deploy/gitignore.ts
+++ b/src/cli/commands/deploy/gitignore.ts
@@ -30,6 +30,7 @@ export async function updateGitignore(spinner: Spinner): Promise<boolean> {
       '# Trinity Method SDK',
       '.claude/trinity/archive/',
       '.claude/trinity/templates/',
+      '*CLAUDE.md',
     ];
 
     // Check if Trinity section already exists

--- a/src/cli/commands/update/index.ts
+++ b/src/cli/commands/update/index.ts
@@ -13,6 +13,11 @@ import { UpdateOptions } from '../../types.js';
 import { runUpdatePreflightChecks } from './pre-flight.js';
 import { detectInstalledSDKVersion } from './version.js';
 import {
+  detectLegacyDeployment,
+  migrateLegacyDeployment,
+  updateGitignoreForMigration,
+} from './migration.js';
+import {
   createUpdateBackup,
   restoreUserContent,
   rollbackFromBackup,
@@ -44,11 +49,26 @@ export async function update(options: UpdateOptions): Promise<void> {
     knowledgeBaseUpdated: 0,
     commandsUpdated: 0,
     filesUpdated: 0,
+    legacyMigrated: false,
+    gitignoreUpdated: false,
   };
 
   try {
     // STEP 1: Pre-flight checks
-    await runUpdatePreflightChecks(spinner);
+    const preflight = await runUpdatePreflightChecks(spinner);
+
+    // STEP 1.5: Legacy migration (pre-2.2.0 trinity/ → .claude/trinity/)
+    if (preflight.needsLegacyMigration) {
+      const legacyInfo = await detectLegacyDeployment(spinner);
+      if (legacyInfo.isLegacy) {
+        await migrateLegacyDeployment(spinner);
+        stats.legacyMigrated = true;
+      }
+    }
+
+    // STEP 1.7: Update .gitignore patterns
+    const gitignoreChanged = await updateGitignoreForMigration(spinner);
+    stats.gitignoreUpdated = gitignoreChanged;
 
     // STEP 2: Version check
     const versionInfo = await detectInstalledSDKVersion(spinner);

--- a/src/cli/commands/update/migration.ts
+++ b/src/cli/commands/update/migration.ts
@@ -1,0 +1,166 @@
+/**
+ * Update Migration Module
+ * Handles legacy deployment detection and migration from pre-2.2.0 structure
+ * @module cli/commands/update/migration
+ */
+
+import fs from 'fs-extra';
+import path from 'path';
+import { Ora } from 'ora';
+import { validatePath } from '../../utils/validate-path.js';
+
+export interface LegacyInfo {
+  isLegacy: boolean;
+  legacyVersion: string | null;
+}
+
+/** Old gitignore patterns from pre-2.2.0 deployments */
+const OLD_GITIGNORE_PATTERNS = ['trinity/', '*CLAUDE.md', 'TRINITY.md'];
+
+/** Current gitignore patterns */
+const CURRENT_GITIGNORE_PATTERNS = [
+  '.claude/trinity/archive/',
+  '.claude/trinity/templates/',
+  '*CLAUDE.md',
+];
+
+/**
+ * Detect if the project has a legacy (pre-2.2.0) Trinity deployment
+ * Legacy deployments use `trinity/` at root instead of `.claude/trinity/`
+ * @param spinner - ora spinner instance for status display
+ * @returns Legacy deployment info
+ */
+export async function detectLegacyDeployment(spinner: Ora): Promise<LegacyInfo> {
+  spinner.start('Checking for legacy deployment...');
+
+  const hasLegacyDir = await fs.pathExists('trinity');
+  const hasLegacyVersion = await fs.pathExists('trinity/VERSION');
+
+  if (!hasLegacyDir) {
+    spinner.info('No legacy deployment detected');
+    return { isLegacy: false, legacyVersion: null };
+  }
+
+  let legacyVersion: string | null = null;
+  if (hasLegacyVersion) {
+    legacyVersion = (await fs.readFile('trinity/VERSION', 'utf8')).trim();
+  }
+
+  spinner.warn(`Legacy deployment detected (v${legacyVersion || 'unknown'})`);
+  return { isLegacy: true, legacyVersion };
+}
+
+/**
+ * Migrate legacy Trinity deployment from `trinity/` to `.claude/trinity/`
+ * Preserves user-managed knowledge base files during migration
+ * @param spinner - ora spinner instance for status display
+ */
+export async function migrateLegacyDeployment(spinner: Ora): Promise<void> {
+  spinner.start('Migrating legacy deployment to .claude/trinity/...');
+
+  // Create new directory structure
+  await fs.ensureDir('.claude/trinity');
+  await fs.ensureDir('.claude/agents/leadership');
+  await fs.ensureDir('.claude/agents/deployment');
+  await fs.ensureDir('.claude/agents/audit');
+  await fs.ensureDir('.claude/agents/planning');
+  await fs.ensureDir('.claude/agents/aj-team');
+  await fs.ensureDir('.claude/commands');
+
+  // Move trinity/ contents to .claude/trinity/
+  const trinityContents = await fs.readdir('trinity');
+  for (const item of trinityContents) {
+    const srcPath = path.join('trinity', item);
+    const destPath = path.join('.claude/trinity', item);
+
+    // Don't overwrite if destination already exists (prefer new structure)
+    if (!(await fs.pathExists(destPath))) {
+      await fs.copy(srcPath, destPath);
+    }
+  }
+
+  // Remove old trinity/ directory
+  await fs.remove('trinity');
+
+  spinner.succeed('Legacy deployment migrated to .claude/trinity/');
+}
+
+/**
+ * Update .gitignore to replace old Trinity patterns with current ones
+ * Safe to run on any deployment — idempotent
+ * @param spinner - ora spinner instance for status display
+ * @returns True if gitignore was updated
+ */
+export async function updateGitignoreForMigration(spinner: Ora): Promise<boolean> {
+  spinner.start('Updating .gitignore patterns...');
+
+  const gitignorePath = '.gitignore';
+
+  if (!(await fs.pathExists(gitignorePath))) {
+    spinner.info('No .gitignore found, skipping');
+    return false;
+  }
+
+  let content = await fs.readFile(gitignorePath, 'utf8');
+  const originalContent = content;
+
+  if (content.includes('# Trinity Method SDK')) {
+    // Remove the existing Trinity section entirely
+    const lines = content.split('\n');
+    const filteredLines: string[] = [];
+    let inTrinitySection = false;
+
+    for (const line of lines) {
+      if (line.trim() === '# Trinity Method SDK') {
+        inTrinitySection = true;
+        continue;
+      }
+
+      // End of Trinity section: next comment or blank line after non-Trinity content
+      if (inTrinitySection) {
+        const trimmed = line.trim();
+        // Still in Trinity section if line is empty, or matches known patterns
+        if (
+          trimmed === '' ||
+          trimmed === 'trinity/' ||
+          trimmed === '*CLAUDE.md' ||
+          trimmed === 'TRINITY.md' ||
+          trimmed === '.claude/trinity/archive/' ||
+          trimmed === '.claude/trinity/templates/'
+        ) {
+          continue;
+        }
+        // Non-Trinity line — we've left the section
+        inTrinitySection = false;
+      }
+
+      filteredLines.push(line);
+    }
+
+    content = filteredLines.join('\n');
+  }
+
+  // Remove any standalone old patterns that might exist outside the section
+  for (const pattern of OLD_GITIGNORE_PATTERNS) {
+    const regex = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'gm');
+    content = content.replace(regex, '');
+  }
+
+  // Clean up multiple blank lines
+  content = content.replace(/\n{3,}/g, '\n\n').trim();
+
+  // Append current Trinity section
+  const trinitySection = ['', '# Trinity Method SDK', ...CURRENT_GITIGNORE_PATTERNS].join('\n');
+
+  content = `${content}\n${trinitySection}\n`;
+
+  if (content === originalContent) {
+    spinner.info('.gitignore already up to date');
+    return false;
+  }
+
+  const validatedPath = validatePath(gitignorePath);
+  await fs.writeFile(validatedPath, content);
+  spinner.succeed('.gitignore patterns updated');
+  return true;
+}

--- a/src/cli/commands/update/pre-flight.ts
+++ b/src/cli/commands/update/pre-flight.ts
@@ -8,35 +8,41 @@ import fs from 'fs-extra';
 import { Ora } from 'ora';
 import { UpdateError } from '../../utils/error-classes.js';
 
+export interface PreflightResult {
+  needsLegacyMigration: boolean;
+}
+
 /**
  * Run pre-flight checks to ensure Trinity Method is deployed
+ * Detects both current (.claude/trinity/) and legacy (trinity/) layouts
  * @param spinner - ora spinner instance for status display
- * @throws {UpdateError} If pre-flight checks fail
+ * @returns Pre-flight result with migration flags
+ * @throws {UpdateError} If no Trinity deployment found at all
  */
-export async function runUpdatePreflightChecks(spinner: Ora): Promise<void> {
+export async function runUpdatePreflightChecks(spinner: Ora): Promise<PreflightResult> {
   spinner.start('Running pre-flight checks...');
 
-  // Check .claude directory exists
   const claudeExists = await fs.pathExists('.claude');
-  if (!claudeExists) {
-    spinner.fail('.claude directory not found');
-    const { displayInfo } = await import('../../utils/errors.js');
-    displayInfo('Use: trinity deploy to install');
-    throw new UpdateError('.claude directory not found', {
-      reason: 'claude_directory_missing',
-    });
-  }
-
-  // Check .claude/trinity directory exists
   const trinityExists = await fs.pathExists('.claude/trinity');
-  if (!trinityExists) {
-    spinner.fail('Trinity Method not deployed');
-    const { displayInfo } = await import('../../utils/errors.js');
-    displayInfo('Trinity deployment appears incomplete');
-    throw new UpdateError('Trinity Method not deployed in this project', {
-      reason: 'trinity_directory_missing',
-    });
+  const legacyExists = await fs.pathExists('trinity');
+
+  // Current structure found — no migration needed
+  if (claudeExists && trinityExists) {
+    spinner.succeed('Pre-flight checks passed');
+    return { needsLegacyMigration: false };
   }
 
-  spinner.succeed('Pre-flight checks passed');
+  // Legacy structure found — migration needed
+  if (legacyExists) {
+    spinner.succeed('Pre-flight checks passed (legacy deployment detected)');
+    return { needsLegacyMigration: true };
+  }
+
+  // Neither found — not deployed
+  spinner.fail('Trinity Method not deployed');
+  const { displayInfo } = await import('../../utils/errors.js');
+  displayInfo('Use: trinity deploy to install');
+  throw new UpdateError('Trinity Method not deployed in this project', {
+    reason: 'trinity_directory_missing',
+  });
 }

--- a/src/cli/commands/update/summary.ts
+++ b/src/cli/commands/update/summary.ts
@@ -26,6 +26,12 @@ export function displayUpdateSummary(
   console.log(chalk.white(`   Commands Updated: ${stats.commandsUpdated}`));
   console.log(chalk.white(`   Templates Updated: ${stats.templatesUpdated}`));
   console.log(chalk.white(`   Knowledge Base Updated: ${stats.knowledgeBaseUpdated}`));
+  if (stats.legacyMigrated) {
+    console.log(chalk.yellow(`   Legacy Migration: trinity/ → .claude/trinity/`));
+  }
+  if (stats.gitignoreUpdated) {
+    console.log(chalk.white(`   .gitignore: Updated`));
+  }
   console.log(
     chalk.white(
       `   Total Files Updated: ${stats.agentsUpdated + stats.commandsUpdated + stats.templatesUpdated + stats.knowledgeBaseUpdated}`

--- a/src/cli/commands/update/types.ts
+++ b/src/cli/commands/update/types.ts
@@ -10,4 +10,6 @@ export interface UpdateStats {
   knowledgeBaseUpdated: number;
   commandsUpdated: number;
   filesUpdated: number;
+  legacyMigrated: boolean;
+  gitignoreUpdated: boolean;
 }

--- a/src/cli/commands/update/version.ts
+++ b/src/cli/commands/update/version.ts
@@ -23,11 +23,12 @@ export interface VersionInfo {
 export async function detectInstalledSDKVersion(spinner: Ora): Promise<VersionInfo> {
   spinner.start('Checking versions...');
 
-  // Read current version from trinity/VERSION
-  const versionPath = '.claude/trinity/VERSION';
+  // Read current version from .claude/trinity/VERSION (or legacy trinity/VERSION)
   let currentVersion = '0.0.0';
-  if (await fs.pathExists(versionPath)) {
-    currentVersion = (await fs.readFile(versionPath, 'utf8')).trim();
+  if (await fs.pathExists('.claude/trinity/VERSION')) {
+    currentVersion = (await fs.readFile('.claude/trinity/VERSION', 'utf8')).trim();
+  } else if (await fs.pathExists('trinity/VERSION')) {
+    currentVersion = (await fs.readFile('trinity/VERSION', 'utf8')).trim();
   }
 
   // Read latest version from SDK package.json

--- a/tests/helpers/test-helpers.ts
+++ b/tests/helpers/test-helpers.ts
@@ -187,3 +187,44 @@ export async function createMockPackageJson(targetDir: string, version: string):
   const pkgPath = path.join(targetDir, 'package.json');
   await fs.writeFile(pkgPath, JSON.stringify({ version }, null, 2));
 }
+
+/**
+ * Create a legacy (pre-2.2.0) mock Trinity deployment structure
+ * Uses trinity/ at root instead of .claude/trinity/
+ */
+export async function createLegacyMockTrinityDeployment(
+  targetDir: string,
+  version: string = '1.0.0'
+): Promise<void> {
+  // Create old-style trinity directory structure at root
+  await fs.ensureDir(path.join(targetDir, 'trinity/knowledge-base'));
+  await fs.ensureDir(path.join(targetDir, 'trinity/sessions'));
+  await fs.ensureDir(path.join(targetDir, 'trinity/templates'));
+
+  // Create VERSION file in old location
+  await fs.writeFile(path.join(targetDir, 'trinity/VERSION'), version);
+
+  // Create user-managed knowledge base files
+  await fs.writeFile(
+    path.join(targetDir, 'trinity/knowledge-base/ARCHITECTURE.md'),
+    '# Architecture\n\nUser custom architecture content'
+  );
+  await fs.writeFile(
+    path.join(targetDir, 'trinity/knowledge-base/To-do.md'),
+    '# To-Do\n\n- [ ] User task 1'
+  );
+  await fs.writeFile(
+    path.join(targetDir, 'trinity/knowledge-base/ISSUES.md'),
+    '# Issues\n\nUser custom issues'
+  );
+  await fs.writeFile(
+    path.join(targetDir, 'trinity/knowledge-base/Technical-Debt.md'),
+    '# Technical Debt\n\nUser custom debt tracking'
+  );
+
+  // Create old-style .gitignore
+  await fs.writeFile(
+    path.join(targetDir, '.gitignore'),
+    '# Trinity Method SDK\ntrinity/\n*CLAUDE.md\nTRINITY.md\n'
+  );
+}

--- a/tests/integration/cli/commands/deploy.test.ts
+++ b/tests/integration/cli/commands/deploy.test.ts
@@ -400,7 +400,7 @@ describe('Deploy Command - Integration Tests', () => {
       expect(gitignoreContent).toContain('# Trinity Method SDK');
       expect(gitignoreContent).toContain('.claude/trinity/archive/');
       expect(gitignoreContent).toContain('.claude/trinity/templates/');
-      expect(gitignoreContent).not.toContain('*CLAUDE.md');
+      expect(gitignoreContent).toContain('*CLAUDE.md');
     });
 
     it('should not duplicate Trinity exclusions if already present', async () => {

--- a/tests/integration/cli/commands/update.test.ts
+++ b/tests/integration/cli/commands/update.test.ts
@@ -10,6 +10,7 @@ import {
   createTempDir,
   cleanupTempDir,
   createMockTrinityDeployment,
+  createLegacyMockTrinityDeployment,
   verifyTrinityStructure,
   readVersion,
   verifyUserFilesPreserved,
@@ -578,6 +579,69 @@ describe('Update Command - Integration Tests', () => {
 
       for (const dir of agentDirs) {
         expect(await fs.pathExists(dir)).toBe(true);
+      }
+    });
+  });
+
+  describe('Legacy Migration', () => {
+    it('should detect old trinity/ directory layout', async () => {
+      await createLegacyMockTrinityDeployment(testDir, '1.0.0');
+
+      // Legacy layout has trinity/ at root, not .claude/trinity/
+      expect(await fs.pathExists('trinity')).toBe(true);
+      expect(await fs.pathExists('trinity/VERSION')).toBe(true);
+      expect(await fs.pathExists('.claude/trinity')).toBe(false);
+    });
+
+    it('should not throw pre-flight error for legacy deployments', async () => {
+      await createLegacyMockTrinityDeployment(testDir, '1.0.0');
+
+      // Update should not throw "Trinity not deployed" for legacy layout
+      // It should detect the legacy dir and attempt migration
+      promptSpy.mockResolvedValueOnce({ confirm: false });
+
+      // Should not throw — pre-flight should pass with legacy detection
+      await expect(update({ dryRun: true })).resolves.not.toThrow();
+    });
+
+    it('should preserve user knowledge base files during migration', async () => {
+      await createLegacyMockTrinityDeployment(testDir, '1.0.0');
+
+      const userContent = 'Custom user architecture notes';
+      await fs.writeFile('trinity/knowledge-base/ARCHITECTURE.md', userContent);
+
+      promptSpy.mockResolvedValueOnce({ confirm: true });
+
+      try {
+        await update({ dryRun: false });
+      } catch {
+        // Update may fail due to missing SDK templates, that's okay
+      }
+
+      // If migration ran, user file should be in new location
+      if (await fs.pathExists('.claude/trinity/knowledge-base/ARCHITECTURE.md')) {
+        const content = await fs.readFile('.claude/trinity/knowledge-base/ARCHITECTURE.md', 'utf8');
+        expect(content).toBe(userContent);
+      }
+    });
+
+    it('should update .gitignore from old to new patterns', async () => {
+      await createLegacyMockTrinityDeployment(testDir, '1.0.0');
+
+      promptSpy.mockResolvedValueOnce({ confirm: true });
+
+      try {
+        await update({ dryRun: false });
+      } catch {
+        // Update may fail after migration, that's okay
+      }
+
+      // Check gitignore was updated (migration runs before version check)
+      if (await fs.pathExists('.gitignore')) {
+        const content = await fs.readFile('.gitignore', 'utf8');
+        expect(content).toContain('.claude/trinity/archive/');
+        expect(content).toContain('.claude/trinity/templates/');
+        expect(content).toContain('*CLAUDE.md');
       }
     });
   });

--- a/tests/unit/cli/commands/update/migration.test.ts
+++ b/tests/unit/cli/commands/update/migration.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit Tests - Update Migration Module
+ * Tests legacy deployment detection, directory migration, and gitignore migration
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import ora from 'ora';
+import {
+  detectLegacyDeployment,
+  migrateLegacyDeployment,
+  updateGitignoreForMigration,
+} from '../../../../../src/cli/commands/update/migration.js';
+
+describe('Update Migration Module', () => {
+  let testDir: string;
+  let originalCwd: string;
+  let spinner: ReturnType<typeof ora>;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'trinity-migration-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    spinner = ora();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await fs.remove(testDir);
+  });
+
+  describe('detectLegacyDeployment', () => {
+    it('should detect legacy trinity/ directory at root', async () => {
+      await fs.ensureDir('trinity/knowledge-base');
+      await fs.writeFile('trinity/VERSION', '1.0.0');
+
+      const result = await detectLegacyDeployment(spinner);
+
+      expect(result.isLegacy).toBe(true);
+      expect(result.legacyVersion).toBe('1.0.0');
+    });
+
+    it('should return false when no legacy directory exists', async () => {
+      const result = await detectLegacyDeployment(spinner);
+
+      expect(result.isLegacy).toBe(false);
+      expect(result.legacyVersion).toBeNull();
+    });
+
+    it('should detect legacy directory without VERSION file', async () => {
+      await fs.ensureDir('trinity/knowledge-base');
+
+      const result = await detectLegacyDeployment(spinner);
+
+      expect(result.isLegacy).toBe(true);
+      expect(result.legacyVersion).toBeNull();
+    });
+
+    it('should return false when only .claude/trinity exists', async () => {
+      await fs.ensureDir('.claude/trinity/knowledge-base');
+      await fs.writeFile('.claude/trinity/VERSION', '2.2.0');
+
+      const result = await detectLegacyDeployment(spinner);
+
+      expect(result.isLegacy).toBe(false);
+      expect(result.legacyVersion).toBeNull();
+    });
+  });
+
+  describe('migrateLegacyDeployment', () => {
+    it('should move trinity/ contents to .claude/trinity/', async () => {
+      await fs.ensureDir('trinity/knowledge-base');
+      await fs.writeFile('trinity/VERSION', '1.0.0');
+      await fs.writeFile('trinity/knowledge-base/ARCHITECTURE.md', 'My architecture');
+
+      await migrateLegacyDeployment(spinner);
+
+      expect(await fs.pathExists('.claude/trinity/VERSION')).toBe(true);
+      expect(await fs.pathExists('.claude/trinity/knowledge-base/ARCHITECTURE.md')).toBe(true);
+      expect(await fs.readFile('.claude/trinity/VERSION', 'utf8')).toBe('1.0.0');
+    });
+
+    it('should preserve user knowledge base files', async () => {
+      const userContent = 'Custom user architecture notes';
+      await fs.ensureDir('trinity/knowledge-base');
+      await fs.writeFile('trinity/knowledge-base/ARCHITECTURE.md', userContent);
+      await fs.writeFile('trinity/knowledge-base/To-do.md', 'User todos');
+      await fs.writeFile('trinity/knowledge-base/ISSUES.md', 'User issues');
+      await fs.writeFile('trinity/knowledge-base/Technical-Debt.md', 'User debt');
+
+      await migrateLegacyDeployment(spinner);
+
+      expect(await fs.readFile('.claude/trinity/knowledge-base/ARCHITECTURE.md', 'utf8')).toBe(
+        userContent
+      );
+      expect(await fs.readFile('.claude/trinity/knowledge-base/To-do.md', 'utf8')).toBe(
+        'User todos'
+      );
+      expect(await fs.readFile('.claude/trinity/knowledge-base/ISSUES.md', 'utf8')).toBe(
+        'User issues'
+      );
+      expect(await fs.readFile('.claude/trinity/knowledge-base/Technical-Debt.md', 'utf8')).toBe(
+        'User debt'
+      );
+    });
+
+    it('should remove old trinity/ directory after migration', async () => {
+      await fs.ensureDir('trinity/knowledge-base');
+      await fs.writeFile('trinity/VERSION', '1.0.0');
+
+      await migrateLegacyDeployment(spinner);
+
+      expect(await fs.pathExists('trinity')).toBe(false);
+    });
+
+    it('should create .claude agent and command directories', async () => {
+      await fs.ensureDir('trinity');
+
+      await migrateLegacyDeployment(spinner);
+
+      expect(await fs.pathExists('.claude/agents/leadership')).toBe(true);
+      expect(await fs.pathExists('.claude/agents/planning')).toBe(true);
+      expect(await fs.pathExists('.claude/agents/deployment')).toBe(true);
+      expect(await fs.pathExists('.claude/agents/audit')).toBe(true);
+      expect(await fs.pathExists('.claude/agents/aj-team')).toBe(true);
+      expect(await fs.pathExists('.claude/commands')).toBe(true);
+    });
+
+    it('should not overwrite existing .claude/trinity files', async () => {
+      // Set up legacy dir with old content
+      await fs.ensureDir('trinity');
+      await fs.writeFile('trinity/VERSION', '1.0.0');
+
+      // Set up new dir with existing content
+      await fs.ensureDir('.claude/trinity');
+      await fs.writeFile('.claude/trinity/VERSION', '2.2.0');
+
+      await migrateLegacyDeployment(spinner);
+
+      // New version should be preserved (not overwritten by old)
+      expect(await fs.readFile('.claude/trinity/VERSION', 'utf8')).toBe('2.2.0');
+    });
+  });
+
+  describe('updateGitignoreForMigration', () => {
+    it('should replace old Trinity patterns with current ones', async () => {
+      const oldGitignore = [
+        'node_modules/',
+        '',
+        '# Trinity Method SDK',
+        'trinity/',
+        '*CLAUDE.md',
+        'TRINITY.md',
+        '',
+        'dist/',
+      ].join('\n');
+      await fs.writeFile('.gitignore', oldGitignore);
+
+      await updateGitignoreForMigration(spinner);
+
+      const content = await fs.readFile('.gitignore', 'utf8');
+      expect(content).toContain('.claude/trinity/archive/');
+      expect(content).toContain('.claude/trinity/templates/');
+      expect(content).toContain('*CLAUDE.md');
+      expect(content).not.toMatch(/^trinity\/$/m);
+      expect(content).not.toMatch(/^TRINITY\.md$/m);
+      expect(content).toContain('node_modules/');
+      expect(content).toContain('dist/');
+    });
+
+    it('should add Trinity section if none exists', async () => {
+      await fs.writeFile('.gitignore', 'node_modules/\ndist/\n');
+
+      await updateGitignoreForMigration(spinner);
+
+      const content = await fs.readFile('.gitignore', 'utf8');
+      expect(content).toContain('# Trinity Method SDK');
+      expect(content).toContain('.claude/trinity/archive/');
+      expect(content).toContain('.claude/trinity/templates/');
+      expect(content).toContain('*CLAUDE.md');
+    });
+
+    it('should be idempotent', async () => {
+      const gitignore = `${[
+        'node_modules/',
+        '',
+        '# Trinity Method SDK',
+        '.claude/trinity/archive/',
+        '.claude/trinity/templates/',
+        '*CLAUDE.md',
+      ].join('\n')}\n`;
+      await fs.writeFile('.gitignore', gitignore);
+
+      const result = await updateGitignoreForMigration(spinner);
+
+      // Should return false since nothing changed
+      expect(result).toBe(false);
+    });
+
+    it('should return false when no .gitignore exists', async () => {
+      const result = await updateGitignoreForMigration(spinner);
+
+      expect(result).toBe(false);
+    });
+
+    it('should preserve non-Trinity entries', async () => {
+      const gitignore = [
+        'node_modules/',
+        '.env',
+        'coverage/',
+        '',
+        '# Trinity Method SDK',
+        'trinity/',
+        '*CLAUDE.md',
+        '',
+        'dist/',
+        'build/',
+      ].join('\n');
+      await fs.writeFile('.gitignore', gitignore);
+
+      await updateGitignoreForMigration(spinner);
+
+      const content = await fs.readFile('.gitignore', 'utf8');
+      expect(content).toContain('node_modules/');
+      expect(content).toContain('.env');
+      expect(content).toContain('coverage/');
+      expect(content).toContain('dist/');
+      expect(content).toContain('build/');
+    });
+
+    it('should handle gitignore with only Trinity section', async () => {
+      const gitignore = '# Trinity Method SDK\ntrinity/\n*CLAUDE.md\n';
+      await fs.writeFile('.gitignore', gitignore);
+
+      await updateGitignoreForMigration(spinner);
+
+      const content = await fs.readFile('.gitignore', 'utf8');
+      expect(content).toContain('# Trinity Method SDK');
+      expect(content).toContain('.claude/trinity/archive/');
+      expect(content).not.toMatch(/^trinity\/$/m);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Restores `*CLAUDE.md` to the `.gitignore` patterns added by `trinity deploy`, preventing project-specific CLAUDE.md files from being committed to version control
- Adds legacy deployment migration to `trinity update` — detects pre-2.2.0 `trinity/` root layouts and automatically migrates them to `.claude/trinity/`, preserving user knowledge base files
- Adds `.gitignore` pattern migration to `trinity update` — replaces old `trinity/` entries with current `.claude/trinity/` patterns on every update run
- Fixes CI depcheck false positive for `markdownlint-cli` and bumps integration test timeout for Windows runners